### PR TITLE
Update wordpress-user-enum.yaml

### DIFF
--- a/common/wordpress-user-enum.yaml
+++ b/common/wordpress-user-enum.yaml
@@ -19,4 +19,4 @@ requests:
       - User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36
     detections:
       - >-
-        StatusCode() == 200 && StringSearch("response", "id")
+        StatusCode() == 200 && StringSearch("response", "avatar_urls")


### PR DESCRIPTION
id tag in response usually respond with false positive, **avatar_urls**  end point might be good to check in the response, cause less false positives.